### PR TITLE
Update pom.xml to use java-vorbis-support from com.github.trilarion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,14 +88,9 @@
 			<version>3.12.0</version>
 		</dependency>
 		<dependency>
-			<groupId>com.googlecode.soundlibs</groupId>
-			<artifactId>tritonus-share</artifactId>
-			<version>0.3.7.4</version>
-		</dependency>
-		<dependency>
-			<groupId>com.googlecode.soundlibs</groupId>
-			<artifactId>vorbisspi</artifactId>
-			<version>1.0.3.3</version>
+			<groupId>com.github.trilarion</groupId>
+			<artifactId>java-vorbis-support</artifactId>
+			<version>1.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.usefulness</groupId>


### PR DESCRIPTION
Changed the vorbis library to something that is actively supported. I am unsure of what bugs you were seeing with the older google library, but the new one works fine for me on an arm64 mac.